### PR TITLE
fix: Update everpay package to resolve crypto/rsa verification error

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "crypto-browserify": "^3.12.0",
     "crypto-js": "^4.2.0",
     "ethers": "^5.7.1",
-    "everpay": "0.6.7",
+    "everpay": "^1.2.1",
     "lodash": "^4.17.21",
     "mime-types": "^2.1.35"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1804,6 +1804,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/crypto-js@^4.2.1":
+  version "4.2.2"
+  resolved "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz#771c4a768d94eb5922cc202a3009558204df0cea"
+  integrity sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.6.tgz#e14b2576a1c25026b7f02ede1de3b84c3a1efeae"
@@ -2201,6 +2206,18 @@ arweave-stream-tx@^1.1.0:
   integrity sha512-bNt9rj0hbAEzoUZEF2s6WJbIz8nasZlZpxIw03Xm8fzb9gRiiZlZGW3lxQLjfc9Z0VRUWDzwtqoYeEoB/JDToQ==
   dependencies:
     exponential-backoff "^3.1.0"
+
+arweave@1.11.9:
+  version "1.11.9"
+  resolved "https://registry.npmjs.org/arweave/-/arweave-1.11.9.tgz#4d1fc17052e4e6d6eeb8fd18063b43eca52f2a56"
+  integrity sha512-i+oQQkQgjASG/+iS/BVq0JDhpW0jLGMtiqPwfHe0x46YCnuA23prN82EW4KigxZAphF9jNzDexQjGLAKbhw4Zw==
+  dependencies:
+    arconnect "^0.4.2"
+    asn1.js "^5.4.1"
+    axios "^0.27.2"
+    base64-js "^1.5.1"
+    bignumber.js "^9.0.2"
+    util "^0.12.4"
 
 arweave@=1.11.8:
   version "1.11.8"
@@ -2768,7 +2785,7 @@ crypto-browserify@^3.12.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-crypto-js@^4.2.0:
+crypto-js@^4.1.1, crypto-js@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
   integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
@@ -3291,15 +3308,17 @@ eventemitter3@^4.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-everpay@0.6.7:
-  version "0.6.7"
-  resolved "https://registry.yarnpkg.com/everpay/-/everpay-0.6.7.tgz#72e9dc9fd5666cfac2921c2e45bce7c0b3918d71"
-  integrity sha512-MC2/zDs/BAUYCvXQ5X2QVkUh1NsoOhXxgYpUUtLxffhrzkpeKZcwYHJ79YaSOdEME4RfB806fqNjnD76HKko5A==
+everpay@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/everpay/-/everpay-1.2.1.tgz#748146cfababdf819af96f2c259e181fc4fd933b"
+  integrity sha512-y/3PfkVufCujoiVSsUqFyajW+Iv7YmXMxCgA+9/3nPpd7ZBjd82goZ2xqW3VL/oncGkEtIuOqn+ukejdojSe7w==
   dependencies:
+    "@types/crypto-js" "^4.2.1"
     "@types/lodash" "^4.14.180"
-    arweave "=1.11.8"
+    arweave "1.11.9"
     axios "^0.21.1"
     bignumber.js "^9.0.1"
+    crypto-js "^4.1.1"
     ethers "^5.4.6"
     keccak "^3.0.2"
     lodash "^4.17.21"


### PR DESCRIPTION
## Summary

This PR updates the Everpay package to fix issue with `payOrder` function throwing `Error: crypto/rsa: verification error` when passing everpay instance using Arweave JWK and address.

```ts
  const arJWK = JSON.parse(readFileSync('<your arweave keyfile>.json')).toString())
  const arAddress = '<your arweave wallet address>'
  const pay = newEverpayByRSA(arJWK, arAddress)
```
I have a repo [here](https://github.com/pawanpaudel93/arseeding-test) to show that the error is fixed when using the latest version of Everpay but throws error when using the Everpay package version arseeding-js is using currently.
